### PR TITLE
fixed unescape bugs

### DIFF
--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -8,6 +8,7 @@ export const unEscapeHTML = (unsafe: any) => {
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
     .replaceAll("&#039;", "'");
 };
 


### PR DESCRIPTION
This commit fixed a highlighter-related bug.

For modern browsers, escape creates `&#39;` instead, using `&#039;` would cause a bug that incompletely unescapes the code, thus forbidding highlighter to work properly.