### PR TITLE
Switch GPT-4 Turbo to the generally available version

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,7 +459,7 @@
         "chatgpt.gpt3.model": {
           "type": "string",
           "enum": [
-            "gpt-4-1106-preview",
+            "gpt-4-turbo",
             "gpt-4",
             "gpt-4-32k",
             "gpt-3.5-turbo",

--- a/src/chatgpt-view-provider.ts
+++ b/src/chatgpt-view-provider.ts
@@ -10,8 +10,7 @@ import { loadTranslations } from './localization';
 import { ActionNames, Conversation, Message, Model, Role, Verbosity } from "./renderer/types";
 import { unEscapeHTML } from "./renderer/utils";
 
-// At the moment, gpt-4-1106-preview means "GPT-4 Turbo"
-const CHATGPT_MODELS = ['gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-1106-preview', 'gpt-4', 'gpt-4-32k'];
+const CHATGPT_MODELS = ['gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-turbo', 'gpt-4', 'gpt-4-32k'];
 
 export interface ApiRequestOptions {
 	command: string,

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -27,7 +27,7 @@ export enum Role {
 
 export enum Model {
   // ChatGPT
-  gpt_4_turbo = "gpt-4-1106-preview",
+  gpt_4_turbo = "gpt-4-turbo",
   gpt_4 = "gpt-4",
   gpt_4_32k = "gpt-4-32k",
   gpt_35_turbo = "gpt-3.5-turbo",


### PR DESCRIPTION
Reference:
- https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4