### PR TITLE
Adding GPT-4o Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "ChatGPT Reborn",
   "icon": "images/ai-logo.jpg",
   "description": "Refactor, improve, and debug your code with GPT-4. This is a fork of the now discontinued vscode-chatgpt extension.",
-  "version": "3.20.2",
+  "version": "3.21.0",
   "aiKey": "",
   "license": "ISC",
   "repository": {
@@ -462,6 +462,7 @@
             "gpt-4-1106-preview",
             "gpt-4",
             "gpt-4-32k",
+            "gpt-4o",
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",
             "text-davinci-003",
@@ -478,6 +479,7 @@
             "gpt-4-turbo",
             "gpt-4",
             "gpt-4-32k",
+            "gpt-4o",
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",
             "text-davinci-003",
@@ -488,9 +490,10 @@
             "code-cushman-001"
           ],
           "markdownEnumDescriptions": [
-            "GPT-4-TURBO, the latest model from OpenAI. 3x cheaper than GPT-4. 16x longer inputs than GPT-4.",
-            "GPT-4, the latest and greatest model from OpenAI. 2x longer inputs than GPT-3.",
-            "GPT-4-32k, the latest and greatest model from OpenAI, with 32k tokens. This is 4x GPT-4 max length and 8x GPT-3 max length.",
+            "GPT-4-TURBO, 3x cheaper than GPT-4. 16x longer inputs than GPT-4.",
+            "GPT-4, 2x longer inputs than GPT-3",
+            "GPT-4-32k, This is 4x GPT-4 max length and 8x GPT-3 max length.",
+            "GPT-4o, newest high speed and cheaper GPT-4 series model",
             "GPT-3.5-TURBO is optimized for chat at 1/10th the cost of `text-davinci-003`.",
             "GPT-3.5-TURBO-16K is the same as `gpt-3.5-turbo` but with 16k tokens."
           ]
@@ -616,7 +619,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@dqbd/tiktoken": "^1.0.7",
+    "@dqbd/tiktoken": "^1.0.15",
     "@reduxjs/toolkit": "^1.9.3",
     "autoprefixer": "^10.4.14",
     "clsx": "^2.0.0",

--- a/package.nls.en.json
+++ b/package.nls.en.json
@@ -1,0 +1,1 @@
+package.nls.json

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -30,6 +30,7 @@ export enum Model {
   gpt_4_turbo = "gpt-4-1106-preview",
   gpt_4 = "gpt-4",
   gpt_4_32k = "gpt-4-32k",
+  gpt_4o = "gpt-4o",
   gpt_35_turbo = "gpt-3.5-turbo",
   gpt_35_turbo_16k = "gpt-3.5-turbo-16k",
   // Prompt completion models - Not yet supported in this extension
@@ -41,6 +42,7 @@ export const MODEL_FRIENDLY_NAME = {
   [Model.gpt_4_turbo]: "GPT-4 Turbo",
   [Model.gpt_4]: "GPT-4",
   [Model.gpt_4_32k]: "GPT-4 32k",
+  [Model.gpt_4o]: "GPT-4o",
   [Model.gpt_35_turbo]: "GPT-3.5 Turbo",
   [Model.gpt_35_turbo_16k]: "GPT-3.5 Turbo 16k",
   [Model.babbage_002]: "Babbage 002",
@@ -60,6 +62,10 @@ export const MODEL_COSTS = {
   [Model.gpt_4_32k]: {
     prompt: 0.06,
     complete: 0.12,
+  },
+  [Model.gpt_4o]: {
+    prompt: 0.005,
+    complete: 0.015,
   },
   [Model.gpt_35_turbo]: {
     prompt: 0.0015,
@@ -95,6 +101,9 @@ export const MODEL_TOKEN_LIMITS = {
   },
   [Model.gpt_4_32k]: {
     context: 32768,
+  },
+  [Model.gpt_4o]: {
+    context: 128000,
   },
   // TODO: Dec 11, 2023 gpt-35-turbo prompt will become 16385 (but complete will remain 4096)
   [Model.gpt_35_turbo]: {


### PR DESCRIPTION
I tried to add support for [GPT-4o](https://platform.openai.com/docs/models/gpt-4o) here. I'm not sure everything is working quite right yet but it's a start.

Remaining issues: 

1. GPT-4o is not yet shown in the quick-switcher.
2. I'm still getting an invalid model error when I try to send a query. I've dumped the debug console as shown below. I don't normally work with JS so I'm not having much luck making sense of it. Anyone able to advise here?

```
rejected promise not handled within 1 second: Error: Invalid model: gpt-4o
extensionHostProcess.js:147
stack trace: Error: Invalid model: gpt-4o
	at module2.exports.__wbindgen_error_new (/Users/nick/Documents/vscode-chatgpt-reborn/out/extension.js:58536:19)
	at wasm://wasm/00b5f812:wasm-function[59]:0x29389
	at module2.exports.encoding_for_model (/Users/nick/Documents/vscode-chatgpt-reborn/out/extension.js:58344:14)
	at ApiProvider.getEncodingForModel (/Users/nick/Documents/vscode-chatgpt-reborn/out/extension.js:64154:51)
	at ApiProvider.countMessageTokens (/Users/nick/Documents/vscode-chatgpt-reborn/out/extension.js:64167:31)
	at a.value (/Users/nick/Documents/vscode-chatgpt-reborn/out/extension.js:64553:45)
	at o.y (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:660)
	at o.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:877)
	at w.$onMessage (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:145:14048)
	at c.S (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:5505)
	at c.Q (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:5271)
	at c.M (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:4361)
	at c.L (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:3579)
	at a.value (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:2227)
	at o.y (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:660)
	at o.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:877)
	at u.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:107:14175)
	at a.value (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:176:8023)
	at o.y (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:660)
	at o.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:82:877)
	at u.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:107:14175)
	at MessagePortMain.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:176:6303)
	at MessagePortMain.emit (node:events:517:28)
	at MessagePortMain._internalPort.emit (node:electron/js2c/utility_init:2:2285)
	at Object.callbackTrampoline (node:internal/async_hooks:130:17)
```