### PR TITLE
Rename Azure API Version setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import pkceChallenge from "./pkce-challenge";
 import { isInstructModel, unEscapeHTML } from "./renderer/helpers";
 import { ApiKeyStatus } from "./renderer/store/app";
 import { ActionNames, ChatMessage, Conversation, Model, Role, Verbosity } from "./renderer/types";
-import { AddFreeTextQuestionMessage, BackendMessageType, BaseBackendMessage, ChangeApiKeyMessage, ChangeApiUrlMessage, EditCodeMessage, ExportToMarkdownMessage, GetSettingsMessage, GetTokenCountMessage, OpenExternalUrlMessage, OpenNewMessage, OpenSettingsMessage, OpenSettingsPromptMessage, RunActionMessage, SetApiVersionMessage, SetConversationListMessage, SetCurrentConversationMessage, SetManualModelInputMessage, SetModelMessage, SetShowAllModelsMessage, SetVerbosityMessage, StopActionMessage, StopGeneratingMessage } from "./renderer/types-messages";
+import { AddFreeTextQuestionMessage, BackendMessageType, BaseBackendMessage, ChangeApiKeyMessage, ChangeApiUrlMessage, EditCodeMessage, ExportToMarkdownMessage, GetSettingsMessage, GetTokenCountMessage, OpenExternalUrlMessage, OpenNewMessage, OpenSettingsMessage, OpenSettingsPromptMessage, RunActionMessage, SetAzureApiVersionMessage, SetConversationListMessage, SetCurrentConversationMessage, SetManualModelInputMessage, SetModelMessage, SetShowAllModelsMessage, SetVerbosityMessage, StopActionMessage, StopGeneratingMessage } from "./renderer/types-messages";
 import Auth from "./secrets-store";
 import Messenger from "./send-to-frontend";
 import { ActionRunner } from "./smart-action-runner";
@@ -452,11 +452,11 @@ export default class ChatGptViewProvider implements vscode.WebviewViewProvider {
 					const changeApiKeyData = data as ChangeApiKeyMessage;
 					this.setApiKey(changeApiKeyData.apiKey);
 					break;
-				case BackendMessageType.setApiVersion:
-					const setApiVersionData = data as SetApiVersionMessage;
-					// this.api.config.apiVersion = setApiVersionData.apiVersion;
-					console.log('Not implemented: setApiVersion');
-					vscode.workspace.getConfiguration("chatgpt").update("apiVersion", setApiVersionData.apiVersion, vscode.ConfigurationTarget.Global);
+				case BackendMessageType.setAzureApiVersion:
+					const setAzureApiVersionData = data as SetAzureApiVersionMessage;
+					// this.api.config.azureApiVersion = setAzureApiVersionData.azureApiVersion;
+					console.log('Not implemented: setAzureApiVersion');
+					vscode.workspace.getConfiguration("chatgpt").update("azureApiVersion", setAzureApiVersionData.azureApiVersion, vscode.ConfigurationTarget.Global);
 					break;
 				case BackendMessageType.getApiKeyStatus:
 					const { status, models } = await this.testApiKey();

--- a/src/openai-api-provider.ts
+++ b/src/openai-api-provider.ts
@@ -331,8 +331,8 @@ export class ApiProvider {
     const resourceName = (endpoint.split('.').shift() ?? endpoint).replace('https://', '');
 
     // TODO: Vercel's 'ai' package doesn't take an API version?
-    // this.config.apiVersion = await vscode.workspace.getConfiguration("chatgpt").get("apiVersion") as string ?? process.env.OPENAI_API_VERSION ?? '2024-02-01';
-    // const apiVersion = await vscode.workspace.getConfiguration("chatgpt").get("apiVersion") as string ?? process.env.OPENAI_API_VERSION ?? '2024-02-01';
+    // this.config.azureApiVersion = await vscode.workspace.getConfiguration("chatgpt").get("azureApiVersion") as string ?? process.env.OPENAI_API_VERSION ?? '2024-02-01';
+    // const azureApiVersion = await vscode.workspace.getConfiguration("chatgpt").get("azureApiVersion") as string ?? process.env.OPENAI_API_VERSION ?? '2024-02-01';
 
     if (!this.deploymentName) {
       console.warn('[Reborn AI] Attempting to set up Azure OpenAI API without a deployment ID. This will likely fail.');

--- a/src/renderer/types-messages.ts
+++ b/src/renderer/types-messages.ts
@@ -32,7 +32,7 @@ export enum BackendMessageType {
   resetApiKey = "resetApiKey",
   generateOpenRouterApiKey = "generateOpenRouterApiKey",
   // API Version
-  setApiVersion = "setApiVersion",
+  setAzureApiVersion = "setAzureApiVersion",
   // Action
   runAction = "runAction",
   stopAction = "stopAction",
@@ -106,9 +106,9 @@ export interface ChangeApiKeyMessage extends BaseBackendMessage {
   apiKey: string;
 }
 
-export interface SetApiVersionMessage extends BaseBackendMessage {
-  type: BackendMessageType.setApiVersion;
-  apiVersion: string;
+export interface SetAzureApiVersionMessage extends BaseBackendMessage {
+  type: BackendMessageType.setAzureApiVersion;
+  azureApiVersion: string;
 }
 
 export interface GetApiKeyStatusMessage extends BaseBackendMessage {

--- a/src/renderer/views/api.tsx
+++ b/src/renderer/views/api.tsx
@@ -16,12 +16,12 @@ interface LlmTemplate {
   name: string;
   instructions: string;
   apiUrl?: URL;
-  apiVersion?: string;
+  azureApiVersion?: string;
   docsUrl?: URL;
   showApiKeyInput?: boolean;
   showAllModelSuggestion?: boolean;
   manualModelInput?: boolean;
-  showApiVersionInput?: boolean;
+  showAzureApiVersionInput?: boolean;
   tested?: boolean;
 }
 const LLM_TEMPLATES: LlmTemplate[] = [
@@ -56,13 +56,13 @@ const LLM_TEMPLATES: LlmTemplate[] = [
     apiUrl: new URL(
       "https://my-service-name.openai.azure.com/deployments/my-deployment-id"
     ),
-    apiVersion: "2024-02-01",
+    azureApiVersion: "2024-02-01",
     docsUrl: new URL(
       "https://learn.microsoft.com/en-us/azure/ai-services/openai/overview"
     ),
     showApiKeyInput: true,
     showAllModelSuggestion: false,
-    showApiVersionInput: true,
+    showAzureApiVersionInput: true,
     tested: true,
   },
   {
@@ -153,7 +153,7 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
   const [showUrlSaved, setShowUrlSaved] = useState(false);
   const [showVersionSaved, setShowVersionSaved] = useState(false);
   const apiUrlInputRef = React.createRef<HTMLInputElement>();
-  const apiVersionInputRef = React.createRef<HTMLInputElement>();
+  const azureApiVersionInputRef = React.createRef<HTMLInputElement>();
   const [lastApiKeyTest, setLastApiKeyTest] = useState<string | null>(null);
   const backendMessenger = useMessenger(vscode);
 
@@ -209,12 +209,12 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
     }
   }, [settings.gpt3.apiBaseUrl]);
 
-  // If the API Version changes, update the text input
+  // If the Azure API Version changes, update the text input
   useEffect(() => {
-    if (apiVersionInputRef.current) {
-      apiVersionInputRef.current.value = settings.apiVersion;
+    if (azureApiVersionInputRef.current) {
+      azureApiVersionInputRef.current.value = settings.azureApiVersion;
     }
-  }, [settings.apiVersion]);
+  }, [settings.azureApiVersion]);
 
   const handleToolChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -231,9 +231,9 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
     if (apiUrlInputRef.current) {
       apiUrlInputRef.current.value = settings.gpt3.apiBaseUrl;
     }
-    // On mount, set the API version input to the current API version
-    if (apiVersionInputRef.current) {
-      apiVersionInputRef.current.value = settings.apiVersion;
+    // On mount, set the Azure API version input to the current Azure API version
+    if (azureApiVersionInputRef.current) {
+      azureApiVersionInputRef.current.value = settings.azureApiVersion;
     }
   }, []);
 
@@ -374,29 +374,29 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
             </div>
           </div>
         )}
-        {selectedTool && selectedTool.apiVersion && (
+        {selectedTool && selectedTool.azureApiVersion && (
           <div>
             <strong className="inline-block mt-2 mb-1">
-              Suggested API Version:
+              Suggested Azure API Version:
             </strong>
             <div className="flex flex-wrap gap-2">
               <CodeBlock
                 margins={false}
                 className="flex-grow"
-                code={selectedTool.apiVersion}
+                code={selectedTool.azureApiVersion}
                 vscode={vscode}
               />
               <button
                 type="button"
                 className="inline-flex items-center px-2.5 py-1.5 text-xs font-medium rounded text-button hover:text-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 bg-button hover:bg-button-hover"
                 onClick={() => {
-                  backendMessenger.sendSetApiVersion(
-                    selectedTool.apiVersion ?? ""
+                  backendMessenger.sendSetAzureApiVersion(
+                    selectedTool.azureApiVersion ?? ""
                   );
 
-                  if (apiVersionInputRef.current) {
-                    apiVersionInputRef.current.value =
-                      selectedTool.apiVersion ?? "";
+                  if (azureApiVersionInputRef.current) {
+                    azureApiVersionInputRef.current.value =
+                      selectedTool.azureApiVersion ?? "";
                   }
 
                   setShowVersionSaved(true);
@@ -406,7 +406,7 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
                   }, 2000);
                 }}
               >
-                Use this API Version
+                Use this Azure API Version
               </button>
             </div>
           </div>
@@ -419,7 +419,7 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
         )}
         {selectedTool &&
           !selectedTool.showAllModelSuggestion &&
-          !selectedTool.showApiVersionInput && (
+          !selectedTool.showAzureApiVersionInput && (
             <p className="mt-2">
               It is recommended you do <strong>not</strong> check the "Show all
               models" checkbox below or a lot of unnecessary models will be
@@ -458,25 +458,25 @@ export default function ApiSettings({ vscode }: { vscode: any }) {
       </section>
 
       {/* Azure only */}
-      {selectedTool?.showApiVersionInput && (
+      {selectedTool?.showAzureApiVersionInput && (
         <section>
           <label
-            htmlFor="apiVersion"
+            htmlFor="azureApiVersion"
             className="block text-md font-medium my-2"
           >
-            <span className="underline">Current</span> API Version of the
+            <span className="underline">Current</span> Azure API Version of the
             deployment:
           </label>
           <div className="relative">
             <input
-              id="apiVersion"
-              ref={apiVersionInputRef}
+              id="azureApiVersion"
+              ref={azureApiVersionInputRef}
               type="text"
               onChange={(e) => {
-                backendMessenger.sendSetApiVersion(e.target.value);
+                backendMessenger.sendSetAzureApiVersion(e.target.value);
               }}
               className="block w-full p-2 text-sm rounded-sm border border-input text-input bg-input outline-0"
-              placeholder={DEFAULT_EXTENSION_SETTINGS.apiVersion}
+              placeholder={DEFAULT_EXTENSION_SETTINGS.azureApiVersion}
             />
             {showVersionSaved && (
               <span className="absolute top-2 right-2 transform px-2 py-0.5 text-green-500 border border-green-500 rounded bg-menu">


### PR DESCRIPTION
Related to #80

Rename the setting 'Api Version' to 'Azure API Version' to clarify its purpose.

* **src/main.ts**
  - Rename the setting 'apiVersion' to 'azureApiVersion'.
  - Update all references to 'apiVersion' to 'azureApiVersion'.

* **src/renderer/views/api.tsx**
  - Rename the setting 'apiVersion' to 'azureApiVersion'.
  - Update all references to 'apiVersion' to 'azureApiVersion'.

* **src/openai-api-provider.ts**
  - Update the setting 'apiVersion' to 'azureApiVersion'.
  - Update all references to 'apiVersion' to 'azureApiVersion'.

* **src/renderer/types-messages.ts**
  - Update the setting 'apiVersion' to 'azureApiVersion'.
  - Update all references to 'apiVersion' to 'azureApiVersion'.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Christopher-Hayes/vscode-chatgpt-reborn/issues/80?shareId=b250adea-6bf5-421c-b555-0b78205adb9d).