### PR TITLE
Add outside-click support to close dropdowns menu for improved UX Motivation

### DIFF
--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -15,6 +15,7 @@ import {
   isOnlineModel,
   useConvertMarkdownToComponent,
   useIsModelAvailable,
+  useOnClickOutside,
 } from "../helpers";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { useMessenger } from "../send-to-backend";
@@ -128,27 +129,11 @@ export default function ModelSelect({
     null
   );
 
-  // Reference to the menu container for outside click detection
+  // Reference to the dropdown container for outside click detection
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close the select menu when clicking outside of it
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowModels(false);
-      }
-    }
-
-    if (showModels) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showModels]);
+  // Close the dropdown menu when clicking outside of it
+  useOnClickOutside(dropdownRef, () => setShowModels(false));
 
   const convertMarkdownToComponent = useConvertMarkdownToComponent(vscode);
 

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -107,6 +107,7 @@ export default function ModelSelect({
 }) {
   const dispatch = useAppDispatch();
   const t = useAppSelector((state: RootState) => state.app.translations);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const [showModels, setShowModels] = useState(false);
   const settings = useAppSelector(
     (state: RootState) => state.app.extensionSettings
@@ -133,7 +134,7 @@ export default function ModelSelect({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close the dropdown menu when clicking outside of it
-  useOnClickOutside(dropdownRef, () => setShowModels(false));
+  useOnClickOutside(dropdownRef, () => setShowModels(false), buttonRef);
 
   const convertMarkdownToComponent = useConvertMarkdownToComponent(vscode);
 
@@ -348,6 +349,7 @@ export default function ModelSelect({
     <>
       <div className={className}>
         <button
+          ref={buttonRef}
           className={classNames(
             `rounded py-0.5 px-1 flex flex-row items-center hover:bg-button-secondary focus:bg-button-secondary whitespace-nowrap hover:text-button-secondary focus:text-button-secondary`,
             {

--- a/src/renderer/components/MoreActionsMenu.tsx
+++ b/src/renderer/components/MoreActionsMenu.tsx
@@ -1,6 +1,6 @@
 import { AdjustmentsHorizontalIcon } from "@heroicons/react/16/solid";
 import classNames from "classnames";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Tooltip } from "react-tooltip";
 import { useAppDispatch, useAppSelector } from "../hooks";
@@ -35,6 +35,29 @@ export default function MoreActionsMenu({
   const backendMessenger = useMessenger(vscode);
   const [showViewOptions, setShowViewOptions] = useState(false);
 
+  // Reference to the menu container for outside click detection
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close the actions menu when clicking outside of it
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setShowMoreActions(false);
+      }
+    }
+
+    if (showMoreActions) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showMoreActions]);
+
+
   // When the show more actions menu is shown, hide the view options menu
   // So, if the user leaves the view options menu open on close, it won't be shown on open
   useEffect(() => {
@@ -47,6 +70,7 @@ export default function MoreActionsMenu({
     <>
       <div
         id="more-actions-menu"
+        ref={menuRef}
         className={classNames(
           "MoreActionsMenu",
           "fixed z-20 right-4 p-2 bg-menu rounded border border-menu overflow-hidden max-w-[calc(100vw-2em)]",

--- a/src/renderer/components/MoreActionsMenu.tsx
+++ b/src/renderer/components/MoreActionsMenu.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Tooltip } from "react-tooltip";
+import { useOnClickOutside } from "../helpers";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { useMessenger } from "../send-to-backend";
 import { RootState } from "../store";
@@ -35,28 +36,11 @@ export default function MoreActionsMenu({
   const backendMessenger = useMessenger(vscode);
   const [showViewOptions, setShowViewOptions] = useState(false);
 
-  // Reference to the menu container for outside click detection
-  const menuRef = useRef<HTMLDivElement>(null);
+  // Reference to the dropdown container for outside click detection
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close the actions menu when clicking outside of it
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setShowMoreActions(false);
-      }
-    }
-
-    if (showMoreActions) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showMoreActions]);
-
+  // Close the dropdown menu when clicking outside of it
+  useOnClickOutside(dropdownRef, () => setShowMoreActions(false));
 
   // When the show more actions menu is shown, hide the view options menu
   // So, if the user leaves the view options menu open on close, it won't be shown on open
@@ -70,7 +54,7 @@ export default function MoreActionsMenu({
     <>
       <div
         id="more-actions-menu"
-        ref={menuRef}
+        ref={dropdownRef}
         className={classNames(
           "MoreActionsMenu",
           "fixed z-20 right-4 p-2 bg-menu rounded border border-menu overflow-hidden max-w-[calc(100vw-2em)]",

--- a/src/renderer/components/MoreActionsMenu.tsx
+++ b/src/renderer/components/MoreActionsMenu.tsx
@@ -21,6 +21,7 @@ export default function MoreActionsMenu({
   showMoreActions,
   setShowMoreActions,
   className,
+  buttonRef,
 }: {
   currentConversation: Conversation;
   conversationList: Conversation[];
@@ -28,6 +29,7 @@ export default function MoreActionsMenu({
   showMoreActions: boolean;
   setShowMoreActions: React.Dispatch<React.SetStateAction<boolean>>;
   className?: string;
+  buttonRef?: React.RefObject<HTMLButtonElement>;
 }) {
   const dispatch = useAppDispatch();
   const t = useAppSelector((state: RootState) => state.app.translations);
@@ -40,7 +42,7 @@ export default function MoreActionsMenu({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close the dropdown menu when clicking outside of it
-  useOnClickOutside(dropdownRef, () => setShowMoreActions(false));
+  useOnClickOutside(dropdownRef, () => setShowMoreActions(false), buttonRef);
 
   // When the show more actions menu is shown, hide the view options menu
   // So, if the user leaves the view options menu open on close, it won't be shown on open

--- a/src/renderer/components/QuestionInputField.tsx
+++ b/src/renderer/components/QuestionInputField.tsx
@@ -40,6 +40,7 @@ export default ({
   );
   const t = useAppSelector((state: any) => state.app.translations);
   const questionInputRef = React.useRef<HTMLTextAreaElement>(null);
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const [showMoreActions, setShowMoreActions] = useState(false);
   const [useEditorSelection, setIncludeEditorSelection] = useState(false);
   const [showTokenBreakdown, setShowTokenBreakdown] = useState(false);
@@ -461,6 +462,7 @@ export default ({
                   setShowMoreActions(!showMoreActions);
                 }
               }}
+              ref={moreActionsButtonRef}
             >
               <Icon icon="zap" className="w-3.5 h-3.5 hidden 2xs:block" />
               {t?.questionInputField?.moreActions ?? "More Actions"}
@@ -473,6 +475,7 @@ export default ({
               currentConversation={currentConversation}
               setShowMoreActions={setShowMoreActions}
               conversationList={conversationList}
+              buttonRef={moreActionsButtonRef}
             />
           </div>
         </div>

--- a/src/renderer/components/VerbositySelect.tsx
+++ b/src/renderer/components/VerbositySelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { useMessenger } from "../send-to-backend";
 import { RootState } from "../store";
@@ -24,6 +24,31 @@ export default function VerbositySelect({
   const dispatch = useAppDispatch();
   const t = useAppSelector((state: RootState) => state.app.translations);
   const [showOptions, setShowOptions] = useState(false);
+
+  // Reference to the menu container for outside click detection
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close the dropdown menu when clicking outside of it
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowOptions(false);
+      }
+    }
+
+    if (showOptions) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showOptions]);
+
+
+
   const backendMessenger = useMessenger(vscode);
 
   const getHumanFriendlyLabel = (verbosity: Verbosity) => {
@@ -55,6 +80,7 @@ export default function VerbositySelect({
   return (
     <>
       <div
+        ref={dropdownRef}  // Attach a ref to the dropdown container so we can detect outside clicks
         className={`${className}`}
         data-tooltip-id={tooltipId ?? "footer-tooltip"}
         data-tooltip-content={

--- a/src/renderer/components/VerbositySelect.tsx
+++ b/src/renderer/components/VerbositySelect.tsx
@@ -28,9 +28,10 @@ export default function VerbositySelect({
 
   // Reference to the dropdown container for outside click detection
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Close the dropdown menu when clicking outside of it
-  useOnClickOutside(dropdownRef, () => setShowOptions(false));
+  useOnClickOutside(dropdownRef, () => setShowOptions(false), buttonRef);
 
   const backendMessenger = useMessenger(vscode);
 
@@ -72,6 +73,7 @@ export default function VerbositySelect({
         }
       >
         <button
+          ref={buttonRef}
           className="rounded py-0.5 px-1 flex flex-row items-center hover:bg-button-secondary focus:bg-button-secondary whitespace-nowrap hover:text-button-secondary focus:text-button-secondary"
           onClick={() => {
             setShowOptions(!showOptions);

--- a/src/renderer/components/VerbositySelect.tsx
+++ b/src/renderer/components/VerbositySelect.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
+import { useOnClickOutside } from "../helpers";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { useMessenger } from "../send-to-backend";
 import { RootState } from "../store";
@@ -25,29 +26,11 @@ export default function VerbositySelect({
   const t = useAppSelector((state: RootState) => state.app.translations);
   const [showOptions, setShowOptions] = useState(false);
 
-  // Reference to the menu container for outside click detection
+  // Reference to the dropdown container for outside click detection
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close the dropdown menu when clicking outside of it
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowOptions(false);
-      }
-    }
-
-    if (showOptions) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showOptions]);
-
-
+  useOnClickOutside(dropdownRef, () => setShowOptions(false));
 
   const backendMessenger = useMessenger(vscode);
 
@@ -80,7 +63,7 @@ export default function VerbositySelect({
   return (
     <>
       <div
-        ref={dropdownRef}  // Attach a ref to the dropdown container so we can detect outside clicks
+        ref={dropdownRef}  // Attach a ref to the dropdown container for outside-click detection
         className={`${className}`}
         data-tooltip-id={tooltipId ?? "footer-tooltip"}
         data-tooltip-content={

--- a/src/renderer/helpers.tsx
+++ b/src/renderer/helpers.tsx
@@ -92,14 +92,14 @@ export const addChatMessage = (
     prev.map((conversation: Conversation) =>
       conversation.id === currentConversationId
         ? {
-            ...conversation,
-            // Add message to conversation; filter is here to prevent duplicate messages
-            messages: [...conversation.messages, newMessage].filter(
-              (message: ChatMessage, index: number, self: ChatMessage[]) =>
-                index ===
-                self.findIndex((m: ChatMessage) => m.id === message.id)
-            ),
-          }
+          ...conversation,
+          // Add message to conversation; filter is here to prevent duplicate messages
+          messages: [...conversation.messages, newMessage].filter(
+            (message: ChatMessage, index: number, self: ChatMessage[]) =>
+              index ===
+              self.findIndex((m: ChatMessage) => m.id === message.id)
+          ),
+        }
         : conversation
     )
   );
@@ -365,7 +365,7 @@ export function isReasoningModel(model: Model | undefined) {
 
 // Custom hook useIsCurrentModelAvailable
 export function useIsModelAvailable(
-  models: Array<{ id: string }>,
+  models: Array<{ id: string; }>,
   model: Model | undefined
 ): boolean {
   return useMemo(() => {
@@ -493,4 +493,24 @@ export function useFormatSize() {
   }, []);
 
   return formatSize;
+}
+
+// Hook - Close the dropdown menu when clicking outside.
+export function useOnClickOutside(
+  ref: React.RefObject<HTMLElement>,
+  handler: () => void
+) {
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref, handler]);
 }

--- a/src/renderer/helpers.tsx
+++ b/src/renderer/helpers.tsx
@@ -498,11 +498,15 @@ export function useFormatSize() {
 // Hook - Close the dropdown menu when clicking outside.
 export function useOnClickOutside(
   ref: React.RefObject<HTMLElement>,
-  handler: () => void
+  handler: () => void,
+  // Use buttonRef to reference the button that opens the dropdown
+  // Without this, the button click would both close and reopen the dropdown
+  buttonRef?: React.RefObject<HTMLElement> | null,
 ) {
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
+      if (ref.current && !ref.current.contains(event.target as Node) &&
+          (!buttonRef || (buttonRef && !buttonRef.current?.contains(event.target as Node)))) {
         handler();
       }
     }


### PR DESCRIPTION
# Reason
While using the extension, I noticed that dropdown menus - such as VerbositySelect, MoreActionsMenu, and ModelSelect - require clicking the trigger button again to close, even after clicking outside the menu. This behavior felt unintuitive and disrupted the flow of interaction, especially when navigating the UI or reading content below the menu.

# Contribution
This PR introduces outside-click support to the following dropdown components:
- `VerbositySelect.tsx`
- `MoreActionsMenu.tsx`
- `ModelSelect.tsx`

Each now uses a consistent ref + mousedown event listener pattern to detect clicks outside the dropdown and automatically close it, enhancing usability and aligning with common UX patterns.

# Changes Summary
Added useRef and useEffect hooks to register global click listeners.

Unified comments and logic across all three dropdown components for maintainability.

Ensured that clicking inside the menu or on a child element does not trigger premature closure.

Verified that all dropdowns still function as expected in responsive and mobile views.

# Outcome
The dropdown experience is now more intuitive. Menus will close automatically when users click elsewhere, reducing unnecessary actions and aligning behavior with user expectations.

If there’s anything that could be improved, I’d really appreciate your guidance or feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
	- Dropdown menus in Model Select, More Actions Menu, and Verbosity Select now automatically close when clicking outside of them for improved user experience.  
	- "More Actions" button in the question input field is now linked to the menu for consistent outside-click detection.

- **Style**  
	- Minor formatting and indentation improvements for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->