### PR TITLE
Sync package.json packageManager with .yarnrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vscode": "^1.70.0",
     "node": ">=20"
   },
-  "packageManager": "yarn@1.22.19",
+  "packageManager": "yarn@1.22.22",
   "categories": [
     "Programming Languages",
     "Machine Learning",


### PR DESCRIPTION
The Yarn binary pinned in `.yarnrc` points to `.yarn/releases/yarn-1.22.22.cjs`,
but commit `cd21b20` left `packageManager` at `yarn@1.22.19`. Update `package.json`
so the declared version matches the bundled release.

GitHub Copilot Summary:

> This pull request updates the `yarn` package manager version in the `package.json` file to ensure compatibility with newer features and bug fixes.
> 
> - Dependency update:
>   * Updated the `packageManager` field to use `yarn@1.22.22` instead of `yarn@1.22.19` in `package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager version (yarn 1.22.19 → 1.22.22). This is an internal tooling upgrade for maintenance; no changes to product behavior, public interfaces, or error handling. The update is transparent to end users and requires no action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->