### PR TITLE
Strengthen build and packaging guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,13 +181,17 @@ catch (error) {
 ## Testing & Build Patterns
 
 ### Build System
+- **Install**: Use `yarn install --frozen-lockfile` (see `package.json`).
 - **Backend**: ESBuild for extension code (`yarn esbuild-base`)
 - **Frontend**: Webpack for React code (`yarn build-webview`)
+- **Full Build**: `yarn build` chains the two scripts and refreshes `out/` bundles.
 - **Watch Mode**: `yarn watch` runs both in parallel
-- **Testing**: VS Code test runner with `@vscode/test-cli`
+- **Testing**: `yarn test` exercises the VS Code test runner (`@vscode/test-cli`); add `xvfb-run -a` only when running headless to avoid X server errors.
+- **Packaging**: `yarn package` delegates to `npx @vscode/vsce package`; VSCE will call the `vscode:prepublish` script during packaging so `out/` artifacts are rebuilt (see scripts in `package.json`).
 
 ### Package Management
-- **Yarn**: This project uses Yarn, not npm or pnpm
+- **Yarn**: Use Yarn; see packageManager in package.json and yarn-path in .yarnrc (under .yarn/releases/); avoid npm or pnpm
+- **Node**: Match the Node version pinned in `.nvmrc`
 - **Scripts**: Defined in `package.json`, use `yarn` prefix for all commands
 
 ## Extension-Specific Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,8 @@ catch (error) {
 - **Frontend**: Webpack for React code (`yarn build-webview`)
 - **Full Build**: `yarn build` chains the two scripts and refreshes `out/` bundles.
 - **Watch Mode**: `yarn watch` runs both in parallel
-- **Testing**: `yarn test` exercises the VS Code test runner (`@vscode/test-cli`); add `xvfb-run -a` only when running headless to avoid X server errors.
+- **Testing**: Use `yarn test` to exercise the VS Code test runner (`@vscode/test-cli`).
+- **Headless Testing**: Add `xvfb-run -a` before `yarn test` when running in a headless environment to avoid X server errors.
 - **Packaging**: `yarn package` delegates to `npx @vscode/vsce package`; VSCE will call the `vscode:prepublish` script during packaging so `out/` artifacts are rebuilt (see scripts in `package.json`).
 
 ### Package Management


### PR DESCRIPTION
GitHub Copilot Summary:

> This pull request updates the build and testing documentation in `AGENTS.md` to clarify and expand instructions for installing dependencies, building, testing, packaging, and managing packages. The changes help ensure contributors use the correct tools and commands, and avoid common pitfalls with environment setup.
> 
> Build and test process improvements:
> 
> * Added instructions to use `yarn install --frozen-lockfile` for dependency installation, referencing `package.json`.
> * Clarified that `yarn build` chains backend and frontend builds and refreshes the `out/` bundles.
> * Expanded testing instructions: `yarn test` runs the VS Code test runner and recommends using `xvfb-run -a` for headless environments to avoid X errors.
> * Added packaging instructions: `yarn package` uses VSCE, which rebuilds `out/` artifacts via the `vscode:prepublish` script.
> 
> Package management and environment setup:
> 
> * Clarified the use of Yarn (not npm or pnpm), referenced `packageManager` in `package.json` and `yarn-path` in `.yarnrc`, and added a note to match the Node version pinned in `.nvmrc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for build and test workflows, including full build steps and artifact refresh notes
  * Added explicit installation instructions and package management recommendations favoring Yarn
  * Included testing procedures and guidance for running tests in headless environments
  * Documented packaging workflow and notes about rebuilt output artifacts
  * Clarified development setup with a pinned Node version and installation prerequisites
<!-- end of auto-generated comment: release notes by coderabbit.ai -->