### PR TITLE
:bug: Fix: reasoning effort dropdown seems to have no effect

### DIFF
--- a/src/openai-api-provider.ts
+++ b/src/openai-api-provider.ts
@@ -143,6 +143,10 @@ export class ApiProvider {
 
     const webSearchTool = this.getWebSearchTool();
 
+    const providerOptions = isReasoningModel(model) && conversation.reasoningEffort ? {
+      openai: { reasoningEffort: conversation.reasoningEffort }
+    } : undefined;
+
     const streamResult = await streamText({
       model: this._openai.languageModel(model),
       messages: conversation.messages.map((message) => ({
@@ -152,11 +156,7 @@ export class ApiProvider {
       tools: webSearchTool ? { web_search: webSearchTool as any } : undefined,
       maxOutputTokens: isReasoningModel(model) ? undefined : completeTokensLeft,
       abortSignal,
-      ...(isReasoningModel(model) && conversation.reasoningEffort ? {
-        experimental_providerMetadata: {
-          openai: { reasoningEffort: conversation.reasoningEffort }
-        }
-      } : {}),
+      ...(providerOptions ? { providerOptions } : {}),
     });
 
     let usedWebSearch = false;
@@ -235,6 +235,10 @@ export class ApiProvider {
 
     const webSearchTool = this.getWebSearchTool();
 
+    const providerOptionsNonStreaming = isReasoningModel(model) && conversation.reasoningEffort ? {
+      openai: { reasoningEffort: conversation.reasoningEffort }
+    } : undefined;
+
     const result = await generateText({
       model: this._openai.languageModel(model),
       messages: conversation.messages.map((message) => ({
@@ -243,11 +247,7 @@ export class ApiProvider {
       })),
       tools: webSearchTool ? { web_search: webSearchTool as any } : undefined,
       maxOutputTokens: isReasoningModel(model) ? undefined : completeTokensLeft,
-      ...(isReasoningModel(model) && conversation.reasoningEffort ? {
-        experimental_providerMetadata: {
-          openai: { reasoningEffort: conversation.reasoningEffort }
-        }
-      } : {}),
+      ...(providerOptionsNonStreaming ? { providerOptions: providerOptionsNonStreaming } : {}),
     });
 
     const usedWebSearch = (result as any)?.toolCalls?.some((tc: any) => tc.toolName === "web_search") ?? false;

--- a/src/renderer/components/ChatMessage.tsx
+++ b/src/renderer/components/ChatMessage.tsx
@@ -10,7 +10,7 @@ import CodeBlock from "./CodeBlock";
 import Icon from "./Icon";
 
 // Error message component.
-const ErrorMessageComponent = ({ message }: { message: ChatMessage }) => {
+const ErrorMessageComponent = ({ message }: { message: ChatMessage; }) => {
   const settings = useAppSelector(
     (state: RootState) => state.app.extensionSettings
   );
@@ -40,7 +40,7 @@ const ErrorMessageComponent = ({ message }: { message: ChatMessage }) => {
 };
 
 // Debug message component.
-const DebugMessageComponent = ({ message }: { message: ChatMessage }) => {
+const DebugMessageComponent = ({ message }: { message: ChatMessage; }) => {
   return (
     <div className="text-xs text-gray-500">
       Message ID: {message?.id} <br />
@@ -320,12 +320,16 @@ const ChatMessageOptions = ({
   vscode: any;
 }) => {
   const t = useAppSelector((state: RootState) => state.app.translations);
+  // Get the up-to-date conversation from Redux store (the prop may be stale due to React Router caching)
+  const upToDateConversation = useAppSelector(
+    (state: RootState) => state.conversation.conversations[conversation.id]
+  ) ?? conversation;
   const backendMessenger = useMessenger(vscode);
 
   const handleSendClick = () => {
     const newQuestion = editingMessageRef.current?.value ?? "";
     backendMessenger.sendAddFreeTextQuestion({
-      conversation,
+      conversation: upToDateConversation,
       question: newQuestion,
       includeEditorSelection: false,
       questionId: message.id,
@@ -338,9 +342,8 @@ const ChatMessageOptions = ({
   return (
     <div className={classNames("flex items-center", className)}>
       <div
-        className={`send-cancel-elements-ext gap-2 ${
-          editingMessageID === message.id ? "" : "hidden"
-        }`}
+        className={`send-cancel-elements-ext gap-2 ${editingMessageID === message.id ? "" : "hidden"
+          }`}
       >
         <button
           className="send-element-ext p-1 pr-2 flex items-center"
@@ -458,9 +461,8 @@ const ChatMessageComponent: React.FC<MessageComponentProps> = ({
 
   return (
     <div
-      className={`group/chat-message w-full flex flex-col gap-y-4 p-4 self-end question-element-ext relative ${
-        message.role === Role.user ? "bg-input" : "bg-sidebar"
-      }`}
+      className={`group/chat-message w-full flex flex-col gap-y-4 p-4 self-end question-element-ext relative ${message.role === Role.user ? "bg-input" : "bg-sidebar"
+        }`}
       key={message.id}
     >
       {hideName ? (

--- a/src/renderer/components/QuestionInputField.tsx
+++ b/src/renderer/components/QuestionInputField.tsx
@@ -39,6 +39,10 @@ export default ({
   const settings = useAppSelector(
     (state: RootState) => state.app.extensionSettings
   );
+  // Get the up-to-date conversation from Redux store (the prop may be stale due to React Router caching)
+  const upToDateConversation = useAppSelector(
+    (state: RootState) => state.conversation.conversations[currentConversation.id]
+  ) ?? currentConversation;
   const t = useAppSelector((state: any) => state.app.translations);
   const questionInputRef = React.useRef<HTMLTextAreaElement>(null);
   const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
@@ -122,8 +126,9 @@ export default ({
         })
       );
 
+      // Use upToDateConversation to ensure we have the latest reasoningEffort and other settings
       backendMessenger.sendAddFreeTextQuestion({
-        conversation: currentConversation,
+        conversation: upToDateConversation,
         question: questionInputRef.current.value,
         includeEditorSelection: useEditorSelection,
       });


### PR DESCRIPTION
Previously, reasoning effort would always use `none` regardless of what option was selected in the GUI. This could be verified by checking the OpenAI dashboard logs (if you've enabled logging of requests) and checking what reasoning effort was used for the request.

This was related to a stale version of the Conversation object being used, which would not have a reasoning effort set on it (yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where conversation settings (such as reasoning effort) were not properly applied when sending follow-up questions, ensuring the latest configuration is used consistently across both message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->